### PR TITLE
Clear out the comment field after submit.

### DIFF
--- a/src/apps/judgment/__template__/index.vue
+++ b/src/apps/judgment/__template__/index.vue
@@ -58,6 +58,7 @@ export default {
       this.node2 = null;
       this.rating = null;
       this.confidence = null;
+      this.comment = "";
       this.startTimer();
       nodeResource.getComparisonNodes().then(nodes => {
         this.node1 = nodes[0];

--- a/src/apps/judgment/example/index.vue
+++ b/src/apps/judgment/example/index.vue
@@ -58,6 +58,7 @@ export default {
       this.node2 = null;
       this.rating = null;
       this.confidence = null;
+      this.comment = "";
       this.startTimer();
       nodeResource.getComparisonNodes().then(nodes => {
         this.node1 = nodes[0];


### PR DESCRIPTION
Since the comment remained after submit, people were re-sbumitting because they thought submission failed.